### PR TITLE
docker: fix final copy operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
+## [0.0.2] - 2023-02-04
+### Fixed
+- (Docker) Fixed plugin directory path
+
 ## [0.0.1] - 2023-02-04
 ### Added
 - Initial Release
 
 [0.0.1]: https://github.com/lizardbyte/themerr-jellyfin/releases/tag/v0.0.1
+[0.0.2]: https://github.com/lizardbyte/themerr-jellyfin/releases/tag/v0.0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,8 @@ _BUILD
 FROM scratch AS deploy
 
 # variables
-ARG PLUGIN_NAME="Themerr"
+ARG PLUGIN_NAME="themerr-jellyfin"
 ARG PLUGIN_DIR="/config/data/plugins"
 
 # add files from buildstage
-COPY --link --from=buildstage /artifacts $PLUGIN_DIR/$PLUGIN_NAME
+COPY --link --from=buildstage /artifacts/ $PLUGIN_DIR/$PLUGIN_NAME


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Fix final copy operation in Dockerfile. It was copying the `artifacts` directory instead of the contents of the directory.
- Rename the destination directory to `themerr-jellyfin` for consistency.
- Update changelog to v0.0.2


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
