### PR TITLE
docker: remove link arg from final copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,4 +91,6 @@ ARG PLUGIN_NAME="themerr-jellyfin"
 ARG PLUGIN_DIR="/config/data/plugins"
 
 # add files from buildstage
-COPY --link --from=buildstage /artifacts/ $PLUGIN_DIR/$PLUGIN_NAME
+# trailing slash on artifacts directory copies the contents of the directory, instead of the directory itself
+# do not use `--link` here, the docker mod will not work
+COPY --from=buildstage /artifacts/ $PLUGIN_DIR/$PLUGIN_NAME


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Removes `--link` arg from final COPY step, which prevents the docker mod from loading the plugin properly.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
