### PR TITLE
ci: pin dotnet version to 6.0.x

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3.0.3
+        with:
+          dotnet-version: "6.0.x"
+
       - name: Build Plugin
         id: jprm
         uses: oddstr13/jellyfin-plugin-repository-manager@v0.5.1
@@ -50,6 +55,7 @@ jobs:
           output: ./build
           version: ${{ needs.check_changelog.outputs.next_version_bare }}
           dotnet-config: Release
+          dotnet-target: net6.0
           verbosity: debug
 
       - name: Rename artifacts


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Since .NET 7.0.200 SDK there is an error with using the action from `oddstr13/jellyfin-plugin-repository-manager`. That repo seems to be somewhat inactive so submitting a fix here by pinning the .NET version as well.

See here for the upstream fix: https://github.com/oddstr13/jellyfin-plugin-repository-manager/pull/85

Referenced jellyfin action jellyfin/jellyfin-meta-plugins/.github/workflows/publish.yaml

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
