### PR TITLE
fix(docker): use single layer for deployed image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,15 +87,22 @@ _BUILD
 # apply permissions to s6 run script
 RUN chmod +x ./dockermod_root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-themerr-config/run
 
-FROM scratch AS deploy
+FROM scratch AS layer_stage
 
 # variables
 ARG PLUGIN_NAME="themerr-jellyfin"
-ARG PLUGIN_DIR="/config/data/plugins"
+ARG PLUGIN_DIR="/root-layer/config/data/plugins"
 
 # add files from buildstage
 # trailing slash on artifacts directory copies the contents of the directory, instead of the directory itself
 COPY --link --from=buildstage /artifacts/ $PLUGIN_DIR/$PLUGIN_NAME
 
 # copy s6 initialization files
-COPY --link --from=buildstage /build/dockermod_root/ /
+COPY --link --from=buildstage /build/dockermod_root/ /root-layer
+
+FROM scratch AS deploy
+
+# Linuxserver.io docker mods require that mods be fully contained in a single layer
+
+# copy s6 initialization files
+COPY --link --from=layer_stage /root-layer/ /


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Linuxserver.io docker mods require that all mod files are contained on a single layer.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #68 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
