### PR TITLE
fix(docker): take ownership of jellyfin plugin configuration directory

### DIFF
--- a/dockermod_root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-themerr-config/run
+++ b/dockermod_root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-themerr-config/run
@@ -18,6 +18,12 @@ echo '
 ╚═══════════════════════════════════════════════════════════════╝
 '
 
+# jellyfin image should handle this, but it does not
+# create plugin configurations directory
+mkdir -p \
+  /config/data/plugins/configurations
+
 lsiown abc:abc \
+  /config/data/plugins/configurations \
   /config/data/plugins/themerr-jellyfin \
   /config/data/plugins/themerr-jellyfin/*


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR is a backup of https://github.com/linuxserver/docker-jellyfin/pull/214 which applies ownership to the Jellyfin plugin configurations directory.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Resolves #68 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
