### PR TITLE
fix(themes): fix incorrect audio container and add unit testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,6 +58,16 @@ jobs:
           dotnet-target: net6.0
           verbosity: debug
 
+      - name: Unit Test
+        id: test
+        run: |
+          dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+
+      - name: Upload coverage
+        # any except cancelled or skipped
+        if: always() && (steps.test.outcome == 'success' || steps.test.outcome == 'failure')
+        uses: codecov/codecov-action@v3
+
       - name: Rename artifacts
         run: |
           mkdir -p artifacts

--- a/Jellyfin.Plugin.Themerr.Tests/Jellyfin.Plugin.Themerr.Tests.csproj
+++ b/Jellyfin.Plugin.Themerr.Tests/Jellyfin.Plugin.Themerr.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Jellyfin.Plugin.Themerr\Jellyfin.Plugin.Themerr.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Jellyfin.Plugin.Themerr.Tests/TestThemerrManager.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/TestThemerrManager.cs
@@ -1,0 +1,103 @@
+using Xunit.Abstractions;
+
+namespace Jellyfin.Plugin.Themerr.Tests;
+
+public class TestThemerrManager
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public TestThemerrManager(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public void TestSaveMp3()
+    {
+        // set destination with themerr_jellyfin_tests as the folder name
+        var destinationFile = Path.Combine(
+            // "themerr_jellyfin_tests",
+            "theme.mp3"
+            );
+        
+        // create a list of youtube urls
+        var videoUrls = new List<string>
+        {
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "https://www.youtube.com/watch?v=yPYZpwSpKmA",
+            "https://www.youtube.com/watch?v=Ghmd4QzT9YY",
+            "https://www.youtube.com/watch?v=LVEWkghDh9A"
+        };
+        foreach (var videoUrl in videoUrls)
+        {
+            // log
+            _testOutputHelper.WriteLine($"Attempting to download {videoUrl}");
+            
+            // run and wait
+            ThemerrManager.SaveMp3(destinationFile, videoUrl);
+            
+            // wait until the file is downloaded
+            Thread.Sleep(5000); // 5 seconds
+            
+            // check if file exists
+            Assert.True(File.Exists(destinationFile));
+            
+            // check if the file is an actual mp3
+            // https://en.wikipedia.org/wiki/List_of_file_signatures
+            var fileBytes = File.ReadAllBytes(destinationFile);
+            var fileBytesHex = BitConverter.ToString(fileBytes);
+            
+            // make sure the file does is not WebM, starts with `1A 45 DF A3`
+            var isNotWebM = !fileBytesHex.StartsWith("1A-45-DF-A3");
+            Assert.True(isNotWebM);
+            
+            // valid mp3 signatures dictionary with offsets
+            var validMp3Signatures = new Dictionary<string, int>
+            {
+                {"66-74-79-70-64-61-73-68", 4}, // Mp4 container?
+                {"66-74-79-70-69-73-6F-6D", 4}, // Mp4 container
+                {"49-44-33", 0}, // ID3
+                {"FF-FB", 0}, // MPEG-1 Layer 3
+                {"FF-F3", 0}, // MPEG-1 Layer 3
+                {"FF-F2", 0} // MPEG-1 Layer 3
+            };
+            
+            // log beginning of fileBytesHex
+            _testOutputHelper.WriteLine($"Beginning of fileBytesHex: {fileBytesHex.Substring(0, 40)}");
+            
+            // check if the file is an actual mp3
+            var isMp3 = false;
+            
+            // loop through validMp3Signatures
+            foreach (var (signature, offset) in validMp3Signatures)
+            {
+                // log
+                _testOutputHelper.WriteLine($"Checking for {signature} at offset of {offset} bytes");
+                
+                // remove the offset bytes
+                var fileBytesHexWithoutOffset = fileBytesHex.Substring(offset * 3);
+                
+                // check if the beginning of the fileBytesHexWithoutOffset matches the signature
+                var isSignature = fileBytesHexWithoutOffset.StartsWith(signature);
+                if (isSignature)
+                {
+                    // log
+                    _testOutputHelper.WriteLine($"Found {signature} at offset {offset}");
+                
+                    // set isMp3 to true
+                    isMp3 = true;
+                
+                    // break out of loop
+                    break;
+                }
+
+                // log
+                _testOutputHelper.WriteLine($"Did not find {signature} at offset {offset}");
+            }
+            Assert.True(isMp3);
+            
+            // delete file
+            File.Delete(destinationFile);
+        }
+    }
+}

--- a/Jellyfin.Plugin.Themerr.Tests/Usings.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Jellyfin.Plugin.Themerr.sln
+++ b/Jellyfin.Plugin.Themerr.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.29905.134
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jellyfin.Plugin.Themerr", "Jellyfin.Plugin.Themerr\Jellyfin.Plugin.Themerr.csproj", "{A6C0029B-F304-4577-92D3-32153DCE1FDC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.Themerr.Tests", "Jellyfin.Plugin.Themerr.Tests\Jellyfin.Plugin.Themerr.Tests.csproj", "{C9967D5D-3EB3-4F41-AB71-0C0330B21644}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{A6C0029B-F304-4577-92D3-32153DCE1FDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A6C0029B-F304-4577-92D3-32153DCE1FDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A6C0029B-F304-4577-92D3-32153DCE1FDC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9967D5D-3EB3-4F41-AB71-0C0330B21644}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9967D5D-3EB3-4F41-AB71-0C0330B21644}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9967D5D-3EB3-4F41-AB71-0C0330B21644}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9967D5D-3EB3-4F41-AB71-0C0330B21644}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Jellyfin.Plugin.Themerr/ThemerrManager.cs
+++ b/Jellyfin.Plugin.Themerr/ThemerrManager.cs
@@ -34,15 +34,18 @@ namespace Jellyfin.Plugin.Themerr
         }
 
         
-        private static void SaveMp3(string destination, string videoUrl)
+        public static void SaveMp3(string destination, string videoUrl)
         {
             Task.Run(async () =>
             {
                 var youtube = new YoutubeClient();
                 var streamManifest = await youtube.Videos.Streams.GetManifestAsync(videoUrl);
 
-                // highest bitrate audio stream
-                var streamInfo = streamManifest.GetAudioOnlyStreams().GetWithHighestBitrate();
+                // highest bitrate audio mp3 stream
+                var streamInfo = streamManifest
+                    .GetAudioOnlyStreams()
+                    .Where(s => s.Container == Container.Mp4)
+                    .GetWithHighestBitrate();
 
                 // Download the stream to a file
                 await youtube.Videos.Streams.DownloadAsync(streamInfo, destination);

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,10 @@ Integrations
    :alt: Read the Docs
    :target: http://themerr-jellyfin.readthedocs.io/
 
+.. image:: https://img.shields.io/codecov/c/gh/LizardByte/Themerr-jellyfin?token=E7LQZ34U04&style=for-the-badge&logo=codecov&label=codecov
+   :alt: Codecov
+   :target: https://codecov.io/gh/LizardByte/Themerr-jellyfin
+
 Downloads
 ---------
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+---
+codecov:
+  branch: master
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 10%
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This "should" fix themes being downloaded in the wrong audio container. Currently they are being downloaded in `WebM`, this changes that to be an `Mp4` container with no video stream.

Additionally, unit testing is added using `Xunit`.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #97 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
