### PR TITLE
fix: improve logging when movie not in ThemerrDB

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,9 @@ dotnet_diagnostic.S125.severity = None
 # Complete the task associated to this 'TODO' comment.
 dotnet_diagnostic.S1135.severity = None
 
+# Remove the unused local variable 'foo'.
+dotnet_diagnostic.S1481.severity = error
+
 # Remove this empty class, write its code or make it an "interface".
 dotnet_diagnostic.S2094.severity = None
 

--- a/Jellyfin.Plugin.Themerr.Tests/FixtureJellyfinServer.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/FixtureJellyfinServer.cs
@@ -60,6 +60,27 @@ public class FixtureJellyfinServer
     }
 
     /// <summary>
+    /// Mock movies without an associated theme in ThemerrDB to use for testing
+    /// </summary>
+    /// <returns>List containing mock <see cref="Movie"/> objects.</returns>
+    public static List<Movie> MockMovies2()
+    {
+        return new List<Movie>
+        {
+            new()
+            {
+                Name = "Themerr Test Movie",
+                ProductionYear = 1970,
+                ProviderIds = new Dictionary<string, string>
+                {
+                    { MetadataProvider.Imdb.ToString(), "tt0000000"},
+                    { MetadataProvider.Tmdb.ToString(), "0"},
+                }
+            },
+        };
+    }
+
+    /// <summary>
     /// Create mock movies from stub video
     /// </summary>
     [Fact]

--- a/Jellyfin.Plugin.Themerr.Tests/TestThemerrManager.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/TestThemerrManager.cs
@@ -44,22 +44,6 @@ public class TestThemerrManager
         return youtubeUrls;
     }
 
-    private List<string> FixtureThemerrDbUrls()
-    {
-        // make list of youtubeUrls to populate
-        var youtubeUrls = new List<string>();
-
-        foreach (var movie in FixtureJellyfinServer.MockMovies())
-        {
-            var tmdbId = movie.ProviderIds[MetadataProvider.Tmdb.ToString()];
-            var themerrDbLink = _themerrManager.CreateThemerrDbLink(tmdbId);
-            youtubeUrls.Add(themerrDbLink);
-        }
-
-        // return the list
-        return youtubeUrls;
-    }
-
     [Fact]
     [Trait("Category", "Unit")]
     private void TestGetExistingThemerrDataValue()
@@ -408,16 +392,79 @@ public class TestThemerrManager
     [Trait("Category", "Unit")]
     private void TestGetYoutubeThemeUrl()
     {
-        // loop over each themerrDbLink
-        foreach (var themerrDbLink in FixtureThemerrDbUrls())
+        // get fixture movies
+        var mockMovies = FixtureJellyfinServer.MockMovies();
+
+        Assert.True(mockMovies.Count > 0, "mockMovies.Count is not greater than 0");
+
+        // loop over each movie
+        foreach (var movie in mockMovies)
         {
+            // get themerrDbUrl
+            var tmdbId = _themerrManager.GetTmdbId(movie);
+            var themerrDbLink = _themerrManager.CreateThemerrDbLink(tmdbId);
+
             // get the new youtube theme url
-            var youtubeThemeUrl = _themerrManager.GetYoutubeThemeUrl(themerrDbLink, $"test{themerrDbLink}");
+            var youtubeThemeUrl = _themerrManager.GetYoutubeThemeUrl(themerrDbLink, movie);
 
             // log
             TestLogger.Info($"youtubeThemeUrl: {youtubeThemeUrl}");
 
             Assert.NotEmpty(youtubeThemeUrl);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    private void TestGetYoutubeThemeUrlExceptions()
+    {
+        // get fixture movies
+        var mockMovies = FixtureJellyfinServer.MockMovies2();
+
+        Assert.True(mockMovies.Count > 0, "mockMovies.Count is not greater than 0");
+
+        // loop over each movie
+        foreach (var movie in mockMovies)
+        {
+            // get themerrDbUrl
+            var tmdbId = _themerrManager.GetTmdbId(movie);
+            var themerrDbLink = _themerrManager.CreateThemerrDbLink(tmdbId);
+
+            // get the new youtube theme url
+            var youtubeThemeUrl = _themerrManager.GetYoutubeThemeUrl(themerrDbLink, movie);
+
+            Assert.Empty(youtubeThemeUrl);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    private void TestGetIssueUrl()
+    {
+        // get fixture movies
+        var mockMovies = FixtureJellyfinServer.MockMovies();
+
+        Assert.True(mockMovies.Count > 0, "mockMovies.Count is not greater than 0");
+
+        // loop over each movie
+        foreach (var movie in mockMovies)
+        {
+            // parts of expected url
+            var tmdbId = _themerrManager.GetTmdbId(movie);
+            var encodedName = movie.Name.Replace(" ", "%20");
+            var year = movie.ProductionYear;
+            var expectedUrl = $"https://github.com/LizardByte/ThemerrDB/issues/new?assignees=&labels=request-theme&template=theme.yml&title=[MOVIE]:%20{encodedName}%20({year})&database_url=https://www.themoviedb.org/movie/{tmdbId}";
+
+            // get the new youtube theme url
+            var issueUrl = _themerrManager.GetIssueUrl(movie);
+
+            Assert.NotEmpty(issueUrl);
+
+            // ensure issue url ends with tmdbId
+            Assert.EndsWith(tmdbId, issueUrl);
+
+            // ensure issue url matches expected url
+            Assert.Equal(expectedUrl, issueUrl);
         }
     }
 

--- a/Jellyfin.Plugin.Themerr/Api/ThemerrController.cs
+++ b/Jellyfin.Plugin.Themerr/Api/ThemerrController.cs
@@ -69,10 +69,6 @@ namespace Jellyfin.Plugin.Themerr.Api
         [ProducesResponseType(StatusCodes.Status200OK)]
         public ActionResult GetProgress()
         {
-            // url components
-            const string issueBase = "https://github.com/LizardByte/ThemerrDB/issues/new?assignees=&labels=request-theme&template=theme.yml&title=[MOVIE]:%20";
-            const string databaseBase = "https://www.themoviedb.org/movie/";
-
             var tmpItems = new ArrayList();
 
             var mediaCount = 0;
@@ -86,15 +82,14 @@ namespace Jellyfin.Plugin.Themerr.Api
 
             foreach (var movie in enumerable)
             {
-                var urlEncodedName = movie.Name.Replace(" ", "%20");
                 var year = movie.ProductionYear;
-                var tmdbId = _themerrManager.GetTmdbId(movie);
+                var issueUrl = _themerrManager.GetIssueUrl(movie);
                 var themeProvider = _themerrManager.GetThemeProvider(movie);
                 var item = new
                 {
                     name = movie.Name,
                     id = movie.Id,
-                    issue_url = $"{issueBase}{urlEncodedName}%20({year})&database_url={databaseBase}{tmdbId}",
+                    issue_url = issueUrl,
                     theme_provider = themeProvider,
                     year = year
                 };


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR adds the ThemerrDB issue (add/edit) url in the logs, when a movie is missing from our database.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
