### PR TITLE
Change title space encoding to full url encoding for github issues

### DIFF
--- a/Jellyfin.Plugin.Themerr.Tests/FixtureJellyfinServer.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/FixtureJellyfinServer.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;

--- a/Jellyfin.Plugin.Themerr.Tests/FixtureJellyfinServer.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/FixtureJellyfinServer.cs
@@ -1,4 +1,4 @@
-using MediaBrowser.Controller.Entities;
+﻿using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
@@ -92,6 +92,16 @@ public class FixtureJellyfinServer
                 {
                     { MetadataProvider.Imdb.ToString(), "tt2661044"},
                     { MetadataProvider.Tmdb.ToString(), "48866"},
+                }
+            },
+            new Series
+            {
+                Name = "Steins;Gate",
+                ProductionYear = 2011,
+                ProviderIds = new Dictionary<string, string>
+                {
+                    { MetadataProvider.Imdb.ToString(), "tt1910272"},
+                    { MetadataProvider.Tmdb.ToString(), "42509"},
                 }
             }
         };

--- a/Jellyfin.Plugin.Themerr.Tests/TestThemerrManager.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/TestThemerrManager.cs
@@ -1,4 +1,4 @@
-using MediaBrowser.Controller.Entities;
+﻿using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
@@ -483,7 +483,7 @@ public class TestThemerrManager
 
         // parts of expected url
         var tmdbId = _themerrManager.GetTmdbId(item);
-        var encodedName = item.Name.Replace(" ", "%20");
+        var encodedName = Uri.EscapeDataString(item.Name);
         var year = item.ProductionYear;
         var expectedUrl = $"https://github.com/LizardByte/ThemerrDB/issues/new?assignees=&labels=request-theme&template=theme.yml&title=[{issueType}]:%20{encodedName}%20({year})&database_url=https://www.themoviedb.org/{tmdbEndpoint}/{tmdbId}";
 

--- a/Jellyfin.Plugin.Themerr.Tests/TestThemerrManager.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/TestThemerrManager.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;

--- a/Jellyfin.Plugin.Themerr/ThemerrManager.cs
+++ b/Jellyfin.Plugin.Themerr/ThemerrManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;

--- a/Jellyfin.Plugin.Themerr/ThemerrManager.cs
+++ b/Jellyfin.Plugin.Themerr/ThemerrManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -371,7 +371,7 @@ namespace Jellyfin.Plugin.Themerr
             string issueBase = $"https://github.com/LizardByte/ThemerrDB/issues/new?assignees=&labels=request-theme&template=theme.yml&title=[{issueBaseTitle}]:%20";
             string databaseBase = $"https://www.themoviedb.org/{tmdbEndpoint}/";
 
-            var urlEncodedName = item.Name.Replace(" ", "%20");
+            var urlEncodedName = Uri.EscapeDataString(item.Name);
             var year = item.ProductionYear;
             var tmdbId = GetTmdbId(item);
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
When Themerr creates a github issue template URL, it only encodes spaces through .replace() and not reserved characters.
This PR simply changes .replace() with Uri.EscapeDataString

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
Closes #292 


## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
