### PR TITLE
fix: ensure ui falls back to english

### DIFF
--- a/Jellyfin.Plugin.Themerr/Api/ThemerrController.cs
+++ b/Jellyfin.Plugin.Themerr/Api/ThemerrController.cs
@@ -151,6 +151,9 @@ namespace Jellyfin.Plugin.Themerr.Api
             // Get the current assembly
             var assembly = Assembly.GetExecutingAssembly();
 
+            // Initialize the result dictionary
+            var result = new Dictionary<string, object>();
+
             for (var i = 0; i < filePaths.Count; i++)
             {
                 // construct the resource name
@@ -167,9 +170,6 @@ namespace Jellyfin.Plugin.Themerr.Api
                     continue;
                 }
 
-                // Initialize the result dictionary
-                var result = new Dictionary<string, object>();
-
                 // read the resource content
                 using var reader = new StreamReader(stream);
                 var json = reader.ReadToEnd();
@@ -179,35 +179,33 @@ namespace Jellyfin.Plugin.Themerr.Api
 
                 // Add the localized strings to the 'locale' key
                 result["locale"] = localizedStrings;
-
-                // Now get the fallback resource
-                var fallbackResourceName = "Jellyfin.Plugin.Themerr.Locale.en.json";
-                using var fallbackStream = assembly.GetManifestResourceStream(fallbackResourceName);
-
-                if (fallbackStream != null)
-                {
-                    // read the fallback resource content
-                    using var fallbackReader = new StreamReader(fallbackStream);
-                    var fallbackJson = fallbackReader.ReadToEnd();
-
-                    // deserialize the fallback JSON content into a dictionary
-                    var fallbackLocalizedStrings =
-                        JsonConvert.DeserializeObject<Dictionary<string, string>>(fallbackJson);
-
-                    // Add the fallback localized strings to the 'fallback' key
-                    result["fallback"] = fallbackLocalizedStrings;
-                }
-                else
-                {
-                    _logger.LogError("Fallback locale resource does not exist: {ResourceName}", fallbackResourceName);
-                }
-
-                // return the result as a JSON object
-                return Ok(result);
             }
 
-            // return an error if we get this far
-            return StatusCode(StatusCodes.Status500InternalServerError);
+            // Now get the fallback resource
+            var fallbackResourceName = "Jellyfin.Plugin.Themerr.Locale.en.json";
+            using var fallbackStream = assembly.GetManifestResourceStream(fallbackResourceName);
+
+            if (fallbackStream != null)
+            {
+                // read the fallback resource content
+                using var fallbackReader = new StreamReader(fallbackStream);
+                var fallbackJson = fallbackReader.ReadToEnd();
+
+                // deserialize the fallback JSON content into a dictionary
+                var fallbackLocalizedStrings =
+                    JsonConvert.DeserializeObject<Dictionary<string, string>>(fallbackJson);
+
+                // Add the fallback localized strings to the 'fallback' key
+                result["fallback"] = fallbackLocalizedStrings;
+            }
+            else
+            {
+                _logger.LogError("Fallback locale resource does not exist: {ResourceName}", fallbackResourceName);
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
+
+            // return the result as a JSON object
+            return Ok(result);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fixes translations issues reported in #296.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
