### PR TITLE
fix: bump Jellyfin to 10.9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,7 +66,7 @@ jobs:
           output: ./build
           version: ${{ needs.setup_release.outputs.release_version }}
           dotnet-config: Release
-          dotnet-target: net6.0
+          dotnet-target: net8.0
           verbosity: debug
 
       - name: Unit Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN <<_DOTNET
 url="https://dot.net/v1/dotnet-install.sh"
 wget --quiet "$url" -O dotnet-install.sh
 chmod +x ./dotnet-install.sh
-./dotnet-install.sh --channel 6.0
+./dotnet-install.sh --channel 8.0
 _DOTNET
 
 # create venv

--- a/Jellyfin.Plugin.Themerr.Tests/Jellyfin.Plugin.Themerr.Tests.csproj
+++ b/Jellyfin.Plugin.Themerr.Tests/Jellyfin.Plugin.Themerr.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Jellyfin.Plugin.Themerr.Tests/TestHelper.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/TestHelper.cs
@@ -1,0 +1,28 @@
+﻿using MediaBrowser.Common.Configuration;
+using Moq;
+
+namespace Jellyfin.Plugin.Themerr.Tests;
+
+/// <summary>
+/// This class is responsible for providing helper methods for testing.
+/// </summary>
+public static class TestHelper
+{
+    /// <summary>
+    /// Gets a mock IApplicationPaths instance.
+    /// </summary>
+    /// <returns>A mock IApplicationPaths instance.</returns>
+    public static Mock<IApplicationPaths> GetMockApplicationPaths()
+    {
+        Mock<IApplicationPaths> mockApplicationPaths = new();
+
+        // Set up the mock IApplicationPaths instance to return valid paths
+        mockApplicationPaths.Setup(a => a.PluginConfigurationsPath).Returns("testing");
+        mockApplicationPaths.Setup(a => a.PluginsPath).Returns("testing");
+        mockApplicationPaths.Setup(a => a.DataPath).Returns("testing");
+        mockApplicationPaths.Setup(a => a.LogDirectoryPath).Returns("testing");
+        mockApplicationPaths.Setup(a => a.CachePath).Returns("testing");
+
+        return mockApplicationPaths;
+    }
+}

--- a/Jellyfin.Plugin.Themerr.Tests/TestThemerrController.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/TestThemerrController.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections;
 using Jellyfin.Plugin.Themerr.Api;
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -24,10 +26,12 @@ public class TestThemerrController
     {
         TestLogger.Initialize(output);
 
+        Mock<IApplicationPaths> mockApplicationPaths = TestHelper.GetMockApplicationPaths();
         Mock<ILibraryManager> mockLibraryManager = new();
         Mock<ILogger<ThemerrController>> mockLogger = new();
         Mock<IServerConfigurationManager> mockServerConfigurationManager = new();
         Mock<ILoggerFactory> mockLoggerFactory = new();
+        Mock<IXmlSerializer> mockXmlSerializer = new();
 
         // Create a TestableServerConfiguration with UICulture set to "en-US"
         var testableServerConfiguration = new TestableServerConfiguration("en-US");
@@ -36,10 +40,12 @@ public class TestThemerrController
         mockServerConfigurationManager.Setup(x => x.Configuration).Returns(testableServerConfiguration);
 
         _controller = new ThemerrController(
+            mockApplicationPaths.Object,
             mockLibraryManager.Object,
             mockLogger.Object,
             mockServerConfigurationManager.Object,
-            mockLoggerFactory.Object);
+            mockLoggerFactory.Object,
+            mockXmlSerializer.Object);
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Themerr.Tests/TestThemerrManager.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/TestThemerrManager.cs
@@ -1,7 +1,9 @@
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Serialization;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
@@ -26,10 +28,16 @@ public class TestThemerrManager
     {
         TestLogger.Initialize(output);
 
+        Mock<IApplicationPaths> mockApplicationPaths = TestHelper.GetMockApplicationPaths();
         Mock<ILibraryManager> mockLibraryManager = new();
         Mock<ILogger<ThemerrManager>> mockLogger = new();
+        Mock<IXmlSerializer> mockXmlSerializer = new();
 
-        _themerrManager = new ThemerrManager(mockLibraryManager.Object, mockLogger.Object);
+        _themerrManager = new ThemerrManager(
+            mockApplicationPaths.Object,
+            mockLibraryManager.Object,
+            mockLogger.Object,
+            mockXmlSerializer.Object);
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Themerr/Api/ThemerrController.cs
+++ b/Jellyfin.Plugin.Themerr/Api/ThemerrController.cs
@@ -6,8 +6,11 @@ using System.Linq;
 using System.Net.Mime;
 using System.Reflection;
 using System.Threading.Tasks;
+using MediaBrowser.Common.Api;
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Serialization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -20,7 +23,7 @@ namespace Jellyfin.Plugin.Themerr.Api
     /// The Themerr api controller.
     /// </summary>
     [ApiController]
-    [Authorize(Policy = "DefaultAuthorization")]
+    [Authorize(Policy = Policies.RequiresElevation)]
     [Route("Themerr")]
     [Produces(MediaTypeNames.Application.Json)]
 
@@ -33,17 +36,25 @@ namespace Jellyfin.Plugin.Themerr.Api
         /// <summary>
         /// Initializes a new instance of the <see cref="ThemerrController"/> class.
         /// </summary>
+        /// <param name="applicationPaths">The application paths.</param>
         /// <param name="libraryManager">The library manager.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="configurationManager">The configuration manager.</param>
         /// <param name="loggerFactory">The logger factory.</param>
+        /// <param name="xmlSerializer">The XML serializer.</param>
         public ThemerrController(
+            IApplicationPaths applicationPaths,
             ILibraryManager libraryManager,
             ILogger<ThemerrController> logger,
             IServerConfigurationManager configurationManager,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            IXmlSerializer xmlSerializer)
         {
-            _themerrManager = new ThemerrManager(libraryManager,  loggerFactory.CreateLogger<ThemerrManager>());
+            _themerrManager = new ThemerrManager(
+                applicationPaths,
+                libraryManager,
+                loggerFactory.CreateLogger<ThemerrManager>(),
+                xmlSerializer);
             _logger = logger;
             _configurationManager = configurationManager;
         }

--- a/Jellyfin.Plugin.Themerr/Jellyfin.Plugin.Themerr.csproj
+++ b/Jellyfin.Plugin.Themerr/Jellyfin.Plugin.Themerr.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
     <FileVersion>0.0.0.0</FileVersion>
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.8.13" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="YoutubeExplode" Version="6.3.14" />
   </ItemGroup>

--- a/Jellyfin.Plugin.Themerr/ScheduledTasks/ThemerrTasks.cs
+++ b/Jellyfin.Plugin.Themerr/ScheduledTasks/ThemerrTasks.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Serialization;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -19,16 +21,24 @@ namespace Jellyfin.Plugin.Themerr.ScheduledTasks
         /// <summary>
         /// Initializes a new instance of the <see cref="ThemerrTasks"/> class.
         /// </summary>
+        /// <param name="applicationPaths">The application paths.</param>
         /// <param name="libraryManager">The library manager.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="loggerFactory">The logger factory.</param>
+        /// <param name="xmlSerializer">The XML serializer.</param>
         public ThemerrTasks(
+            IApplicationPaths applicationPaths,
             ILibraryManager libraryManager,
             ILogger<ThemerrTasks> logger,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            IXmlSerializer xmlSerializer)
         {
             _logger = logger;
-            _themerrManager = new ThemerrManager(libraryManager,  loggerFactory.CreateLogger<ThemerrManager>());
+            _themerrManager = new ThemerrManager(
+                applicationPaths,
+                libraryManager,
+                loggerFactory.CreateLogger<ThemerrManager>(),
+                xmlSerializer);
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.Themerr/ThemerrManager.cs
+++ b/Jellyfin.Plugin.Themerr/ThemerrManager.cs
@@ -5,12 +5,15 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.Themerr.Configuration;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Plugins;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Plugins;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Serialization;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using YoutubeExplode;
@@ -21,7 +24,7 @@ namespace Jellyfin.Plugin.Themerr
     /// <summary>
     /// The main entry point for the plugin.
     /// </summary>
-    public class ThemerrManager : IServerEntryPoint
+    public class ThemerrManager : BasePlugin<PluginConfiguration>
     {
         private readonly ILibraryManager _libraryManager;
         private readonly Timer _timer;
@@ -30,14 +33,26 @@ namespace Jellyfin.Plugin.Themerr
         /// <summary>
         /// Initializes a new instance of the <see cref="ThemerrManager"/> class.
         /// </summary>
+        /// <param name="applicationPaths">The application paths.</param>
         /// <param name="libraryManager">The library manager.</param>
         /// <param name="logger">The logger.</param>
-        public ThemerrManager(ILibraryManager libraryManager, ILogger<ThemerrManager> logger)
+        /// <param name="xmlSerializer">The XML serializer.</param>
+        public ThemerrManager(
+            IApplicationPaths applicationPaths,
+            ILibraryManager libraryManager,
+            ILogger<ThemerrManager> logger,
+            IXmlSerializer xmlSerializer)
+            : base(applicationPaths, xmlSerializer)
         {
             _libraryManager = libraryManager;
             _logger = logger;
             _timer = new Timer(_ => OnTimerElapsed(), null, Timeout.Infinite, Timeout.Infinite);
         }
+
+        /// <summary>
+        /// Gets the plugin instance.
+        /// </summary>
+        public override string Name => "Themerr";
 
         /// <summary>
         /// Get a value from the themerr data file if it exists.

--- a/build.yaml
+++ b/build.yaml
@@ -2,8 +2,8 @@
 name: "Themerr"
 image: "themerr-jellyfin.png"
 guid: "e41ef0c4-c413-41ba-b4fa-8c565dc3c969"
-targetAbi: "10.8.13.0"
-framework: "net6.0"
+targetAbi: "10.9.0.0"
+framework: "net8.0"
 overview: "Automatically add theme songs to movies using ThemerrDB"
 description: >-
   Automatically add theme songs to movies using ThemerrDB


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Bump jellyfin controller from 10.8.13 to 10.9.0.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Resolves #310 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
