### PR TITLE
ci: use prerelease logic

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,26 +10,16 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:
   setup_release:
     name: Setup Release
     outputs:
-      changelog_changes: ${{ steps.setup_release.outputs.changelog_changes }}
-      changelog_date: ${{ steps.setup_release.outputs.changelog_date }}
-      changelog_exists: ${{ steps.setup_release.outputs.changelog_exists }}
-      changelog_release_exists: ${{ steps.setup_release.outputs.changelog_release_exists }}
-      changelog_url: ${{ steps.setup_release.outputs.changelog_url }}
-      changelog_version: ${{ steps.setup_release.outputs.changelog_version }}
-      publish_pre_release: ${{ steps.setup_release.outputs.publish_pre_release }}
       publish_release: ${{ steps.setup_release.outputs.publish_release }}
-      publish_stable_release: ${{ steps.setup_release.outputs.publish_stable_release }}
-      release_body: ${{ steps.setup_release.outputs.release_body }}
       release_build: ${{ steps.setup_release.outputs.release_build }}
       release_commit: ${{ steps.setup_release.outputs.release_commit }}
-      release_generate_release_notes: ${{ steps.setup_release.outputs.release_generate_release_notes }}
       release_tag: ${{ steps.setup_release.outputs.release_tag }}
       release_version: ${{ steps.setup_release.outputs.release_version }}
     runs-on: ubuntu-latest
@@ -39,7 +29,7 @@ jobs:
 
       - name: Setup Release
         id: setup_release
-        uses: LizardByte/setup-release-action@v2024.516.190324
+        uses: LizardByte/setup-release-action@v2024.520.193857
         with:
           dotnet: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -99,23 +89,12 @@ jobs:
 
       - name: Create/Update GitHub Release
         if: ${{ needs.setup_release.outputs.publish_release == 'true' }}
-        uses: LizardByte/create-release-action@v2024.516.190229
+        uses: LizardByte/create-release-action@v2024.520.193838
         with:
           allowUpdates: true
-          body: ''
           discussionCategory: announcements
           generateReleaseNotes: true
           name: ${{ needs.setup_release.outputs.release_tag }}
-          prerelease: ${{ needs.setup_release.outputs.publish_pre_release }}
+          prerelease: true
           tag: ${{ needs.setup_release.outputs.release_tag }}
           token: ${{ secrets.GH_BOT_TOKEN }}
-
-      - name: Create/Update Jellyfin Release
-        if: ${{ needs.setup_release.outputs.publish_release == 'true' }}
-        uses: LizardByte/jellyfin-plugin-repo@v2024.516.183604
-        with:
-          github_token: ${{ secrets.GH_BOT_TOKEN }}
-          committer_email: ${{ secrets.GH_BOT_EMAIL }}
-          committer_name: ${{ secrets.GH_BOT_NAME }}
-          release_tag: ${{ needs.setup_release.outputs.release_tag }}
-          zipfile: ./artifacts/themerr-jellyfin.zip

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -29,7 +29,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:
@@ -102,19 +102,9 @@ jobs:
     needs:
       - check_dockerfiles
     outputs:
-      changelog_changes: ${{ steps.setup_release.outputs.changelog_changes }}
-      changelog_date: ${{ steps.setup_release.outputs.changelog_date }}
-      changelog_exists: ${{ steps.setup_release.outputs.changelog_exists }}
-      changelog_release_exists: ${{ steps.setup_release.outputs.changelog_release_exists }}
-      changelog_url: ${{ steps.setup_release.outputs.changelog_url }}
-      changelog_version: ${{ steps.setup_release.outputs.changelog_version }}
-      publish_pre_release: ${{ steps.setup_release.outputs.publish_pre_release }}
       publish_release: ${{ steps.setup_release.outputs.publish_release }}
-      publish_stable_release: ${{ steps.setup_release.outputs.publish_stable_release }}
-      release_body: ${{ steps.setup_release.outputs.release_body }}
       release_build: ${{ steps.setup_release.outputs.release_build }}
       release_commit: ${{ steps.setup_release.outputs.release_commit }}
-      release_generate_release_notes: ${{ steps.setup_release.outputs.release_generate_release_notes }}
       release_tag: ${{ steps.setup_release.outputs.release_tag }}
       release_version: ${{ steps.setup_release.outputs.release_version }}
     runs-on: ubuntu-latest
@@ -124,7 +114,7 @@ jobs:
 
       - name: Setup Release
         id: setup_release
-        uses: LizardByte/setup-release-action@v2024.516.190324
+        uses: LizardByte/setup-release-action@v2024.520.181643
         with:
           dotnet: ${{ needs.check_dockerfiles.outputs.dotnet }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -171,7 +161,7 @@ jobs:
 
     steps:
       - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
+        uses: easimon/maximize-build-space@v10
         with:
           root-reserve-mb: 30720  # https://github.com/easimon/maximize-build-space#caveats
           remove-dotnet: 'true'
@@ -287,7 +277,7 @@ jobs:
         id: buildx
 
       - name: Cache Docker Layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: Docker-buildx${{ matrix.tag }}-${{ github.sha }}
@@ -373,21 +363,20 @@ jobs:
 
       - name: Create/Update GitHub Release
         if: ${{ needs.setup_release.outputs.publish_release == 'true' && steps.prepare.outputs.artifacts == 'true' }}
-        uses: LizardByte/create-release-action@v2024.516.190229
+        uses: LizardByte/create-release-action@v2024.520.180003
         with:
           allowUpdates: true
           artifacts: "*artifacts/*"
-          body: ''
           discussionCategory: announcements
           generateReleaseNotes: true
           name: ${{ needs.setup_release.outputs.release_tag }}
-          prerelease: ${{ needs.setup_release.outputs.publish_pre_release }}
+          prerelease: true
           tag: ${{ needs.setup_release.outputs.release_tag }}
           token: ${{ secrets.GH_BOT_TOKEN }}
 
       - name: Update Docker Hub Description
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}  # token is not currently supported

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,31 @@
+---
+# This action is centrally managed in https://github.com/<organization>/.github/
+# Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in
+# the above-mentioned repo.
+
+# Update changelog on release events.
+
+name: Update changelog
+
+on:
+  release:
+    types: [created, edited, deleted]
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}"
+  cancel-in-progress: true
+
+jobs:
+  update-changelog:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.release.prerelease && !github.event.release.draft)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Changelog
+        uses: LizardByte/update-changelog-action@v2024.520.183314
+        with:
+          changelogBranch: changelog
+          changelogFile: CHANGELOG.md
+          token: ${{ secrets.GH_BOT_TOKEN }}

--- a/.github/workflows/update-jellyfin-release.yml
+++ b/.github/workflows/update-jellyfin-release.yml
@@ -1,0 +1,93 @@
+---
+# This action is a candidate to centrally manage in https://github.com/<organization>/.github/
+# If more Jellyfin plugins are developed, consider moving this action to the organization's .github repository,
+# using the `jellyfin-plugin` repository label to identify repositories that should trigger have this workflow.
+
+# Update Jellyfin repository on release events.
+
+name: Update Jellyfin release
+
+on:
+  release:
+    types: [created, edited, deleted]
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.release.tag_name }}"
+  cancel-in-progress: false
+
+jobs:
+  update-jellyfin-release:
+    if: >-
+      !github.event.release.draft && !github.event.release.prerelease
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if Jellyfin repo
+        id: isJellyfinRepo
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const repo = context.payload.repository;
+            const repoLabels = await github.repos.listLabelsForRepo({
+              owner: repo.owner.login,
+              repo: repo.name
+            });
+            const isJellyfinRepo = repoLabels.data.some(label => label.name === 'jellyfin-plugin');
+            core.setOutput('isJellyfinRepo', isJellyfinRepo);
+
+      - name: Download release asset
+        id: download
+        if: >-
+          steps.isJellyfinRepo.outputs.isJellyfinRepo == 'true' &&
+          github.event.action != 'deleted'
+        uses: robinraju/release-downloader@v1.10
+        with:
+          repository: "${{ github.repository }}"
+          tag: "${{ github.event.release.tag_name }}"
+          fileName: "*.zip"
+          tarBall: false
+          zipBall: false
+          out-file-path: "release_downloads"
+          extract: false
+
+      - name: Loop through downloaded files
+        if: >-
+          steps.isJellyfinRepo.outputs.isJellyfinRepo == 'true' &&
+          github.event.action != 'deleted'
+        id: loop
+        run: |
+          files=${{ fromJson(steps.download.outputs.downloaded_files) }}
+          file_number=0
+          plugin=""
+          for file in "${files[@]}"; do
+            echo "$file"
+
+            # extract the zip file
+            unzip -o $file -d ./release_downloads/$file_number
+
+            # check if the extracted file contains a meta.json file
+            if [ -f ./release_downloads/$file_number/meta.json ]; then
+              plugin=$file
+              break
+            fi
+
+            file_number=$((file_number+1))
+          done
+
+          if [ -z "$plugin" ]; then
+            echo "No plugin found in the downloaded files"
+            exit 1
+          fi
+
+          echo "plugin_zip=$plugin" >> $GITHUB_OUTPUT
+
+      - name: Create/Update Jellyfin Release
+        if: >-
+          steps.isJellyfinRepo.outputs.isJellyfinRepo == 'true'
+        uses: LizardByte/jellyfin-plugin-repo@v2024.522.143446
+        with:
+          action: ${{ github.event.action == 'deleted' && 'remove' || 'add' }}
+          github_token: ${{ secrets.GH_BOT_TOKEN }}
+          committer_email: ${{ secrets.GH_BOT_EMAIL }}
+          committer_name: ${{ secrets.GH_BOT_NAME }}
+          release_tag: ${{ github.event.release.tag_name }}
+          zipfile: ${{ steps.loop.outputs.plugin_zip }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Use new prerelease logic.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
