### PR TITLE
ci: fix octokit in update-jellyfin-release.yml

### DIFF
--- a/.github/workflows/update-jellyfin-release.yml
+++ b/.github/workflows/update-jellyfin-release.yml
@@ -26,12 +26,10 @@ jobs:
         id: isJellyfinRepo
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_BOT_TOKEN }}
           script: |
-            const repo = context.payload.repository;
-            const repoLabels = await github.repos.listLabelsForRepo({
-              owner: repo.owner.login,
-              repo: repo.name
+            const repoLabels = await github.rest.issues.listLabelsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo
             });
             const isJellyfinRepo = repoLabels.data.some(label => label.name === 'jellyfin-plugin');
             core.setOutput('isJellyfinRepo', isJellyfinRepo);


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
repoLabels is not properly being initialized.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
