### PR TITLE
fix: remove BasePlugin inheritance from ThemerrManager

### DIFF
--- a/Jellyfin.Plugin.Themerr.Tests/TestThemerrController.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/TestThemerrController.cs
@@ -1,9 +1,7 @@
 ﻿using System.Collections;
 using Jellyfin.Plugin.Themerr.Api;
-using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -26,12 +24,10 @@ public class TestThemerrController
     {
         TestLogger.Initialize(output);
 
-        Mock<IApplicationPaths> mockApplicationPaths = TestHelper.GetMockApplicationPaths();
         Mock<ILibraryManager> mockLibraryManager = new();
         Mock<ILogger<ThemerrController>> mockLogger = new();
         Mock<IServerConfigurationManager> mockServerConfigurationManager = new();
         Mock<ILoggerFactory> mockLoggerFactory = new();
-        Mock<IXmlSerializer> mockXmlSerializer = new();
 
         // Create a TestableServerConfiguration with UICulture set to "en-US"
         var testableServerConfiguration = new TestableServerConfiguration("en-US");
@@ -40,12 +36,10 @@ public class TestThemerrController
         mockServerConfigurationManager.Setup(x => x.Configuration).Returns(testableServerConfiguration);
 
         _controller = new ThemerrController(
-            mockApplicationPaths.Object,
             mockLibraryManager.Object,
             mockLogger.Object,
             mockServerConfigurationManager.Object,
-            mockLoggerFactory.Object,
-            mockXmlSerializer.Object);
+            mockLoggerFactory.Object);
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Themerr.Tests/TestThemerrManager.cs
+++ b/Jellyfin.Plugin.Themerr.Tests/TestThemerrManager.cs
@@ -1,9 +1,7 @@
-using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Serialization;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
@@ -29,10 +27,8 @@ public class TestThemerrManager
     {
         TestLogger.Initialize(output);
 
-        Mock<IApplicationPaths> mockApplicationPaths = TestHelper.GetMockApplicationPaths();
         Mock<ILibraryManager> mockLibraryManager = new();
         Mock<ILogger<ThemerrManager>> mockLogger = new();
-        Mock<IXmlSerializer> mockXmlSerializer = new();
 
         var audioStubPath = Path.Combine(Directory.GetCurrentDirectory(), "data", "audio_stub.mp3");
 
@@ -46,16 +42,12 @@ public class TestThemerrManager
             });
 
         _themerrManager = new ThemerrManager(
-            mockApplicationPaths.Object,
             mockLibraryManager.Object,
-            mockLogger.Object,
-            mockXmlSerializer.Object);
+            mockLogger.Object);
 
         _themerrManagerWithMockYoutube = new ThemerrManager(
-            mockApplicationPaths.Object,
             mockLibraryManager.Object,
             mockLogger.Object,
-            mockXmlSerializer.Object,
             mockYoutubeClient.Object);
     }
 

--- a/Jellyfin.Plugin.Themerr/Api/ThemerrController.cs
+++ b/Jellyfin.Plugin.Themerr/Api/ThemerrController.cs
@@ -7,10 +7,8 @@ using System.Net.Mime;
 using System.Reflection;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Api;
-using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Serialization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -36,25 +34,19 @@ namespace Jellyfin.Plugin.Themerr.Api
         /// <summary>
         /// Initializes a new instance of the <see cref="ThemerrController"/> class.
         /// </summary>
-        /// <param name="applicationPaths">The application paths.</param>
         /// <param name="libraryManager">The library manager.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="configurationManager">The configuration manager.</param>
         /// <param name="loggerFactory">The logger factory.</param>
-        /// <param name="xmlSerializer">The XML serializer.</param>
         public ThemerrController(
-            IApplicationPaths applicationPaths,
             ILibraryManager libraryManager,
             ILogger<ThemerrController> logger,
             IServerConfigurationManager configurationManager,
-            ILoggerFactory loggerFactory,
-            IXmlSerializer xmlSerializer)
+            ILoggerFactory loggerFactory)
         {
             _themerrManager = new ThemerrManager(
-                applicationPaths,
                 libraryManager,
-                loggerFactory.CreateLogger<ThemerrManager>(),
-                xmlSerializer);
+                loggerFactory.CreateLogger<ThemerrManager>());
             _logger = logger;
             _configurationManager = configurationManager;
         }

--- a/Jellyfin.Plugin.Themerr/ScheduledTasks/ThemerrTasks.cs
+++ b/Jellyfin.Plugin.Themerr/ScheduledTasks/ThemerrTasks.cs
@@ -2,9 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Serialization;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -21,24 +19,18 @@ namespace Jellyfin.Plugin.Themerr.ScheduledTasks
         /// <summary>
         /// Initializes a new instance of the <see cref="ThemerrTasks"/> class.
         /// </summary>
-        /// <param name="applicationPaths">The application paths.</param>
         /// <param name="libraryManager">The library manager.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="loggerFactory">The logger factory.</param>
-        /// <param name="xmlSerializer">The XML serializer.</param>
         public ThemerrTasks(
-            IApplicationPaths applicationPaths,
             ILibraryManager libraryManager,
             ILogger<ThemerrTasks> logger,
-            ILoggerFactory loggerFactory,
-            IXmlSerializer xmlSerializer)
+            ILoggerFactory loggerFactory)
         {
             _logger = logger;
             _themerrManager = new ThemerrManager(
-                applicationPaths,
                 libraryManager,
-                loggerFactory.CreateLogger<ThemerrManager>(),
-                xmlSerializer);
+                loggerFactory.CreateLogger<ThemerrManager>());
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.Themerr/ThemerrManager.cs
+++ b/Jellyfin.Plugin.Themerr/ThemerrManager.cs
@@ -6,15 +6,11 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
-using Jellyfin.Plugin.Themerr.Configuration;
-using MediaBrowser.Common.Configuration;
-using MediaBrowser.Common.Plugins;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Serialization;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -23,7 +19,7 @@ namespace Jellyfin.Plugin.Themerr
     /// <summary>
     /// The main entry point for the plugin.
     /// </summary>
-    public class ThemerrManager : BasePlugin<PluginConfiguration>, IDisposable
+    public class ThemerrManager : IDisposable
     {
         private readonly ILibraryManager _libraryManager;
         private readonly Timer _timer;
@@ -33,29 +29,19 @@ namespace Jellyfin.Plugin.Themerr
         /// <summary>
         /// Initializes a new instance of the <see cref="ThemerrManager"/> class.
         /// </summary>
-        /// <param name="applicationPaths">The application paths.</param>
         /// <param name="libraryManager">The library manager.</param>
         /// <param name="logger">The logger.</param>
-        /// <param name="xmlSerializer">The XML serializer.</param>
         /// <param name="youtubeClientWrapper">The YouTube client wrapper. Uses the default implementation when null.</param>
         public ThemerrManager(
-            IApplicationPaths applicationPaths,
             ILibraryManager libraryManager,
             ILogger<ThemerrManager> logger,
-            IXmlSerializer xmlSerializer,
             IYoutubeClientWrapper youtubeClientWrapper = null)
-            : base(applicationPaths, xmlSerializer)
         {
             _libraryManager = libraryManager;
             _logger = logger;
             _timer = new Timer(_ => OnTimerElapsed(), null, Timeout.Infinite, Timeout.Infinite);
             _youtubeClientWrapper = youtubeClientWrapper ?? new YoutubeClientWrapper();
         }
-
-        /// <summary>
-        /// Gets the plugin instance.
-        /// </summary>
-        public override string Name => "Themerr";
 
         /// <summary>
         /// Get a value from the themerr data file if it exists.


### PR DESCRIPTION

## Description

ThemerrManager and ThemerrPlugin both extended BasePlugin<PluginConfiguration>, giving the assembly two IPlugin implementations. Jellyfin's loader picked one non-deterministically; when it chose ThemerrManager (which has no IHasWebPages), the config page URL returned 404. This bug was introduced in #189 when ThemerrPlugin was split out but ThemerrManager was never cleaned up.

ThemerrManager never used Configuration, ApplicationPaths, or XmlSerializer from its BasePlugin base — those parameters only existed to satisfy the base constructor call and are now removed throughout the call chain.

### Screenshot



### Issues Fixed or Closed
Fixes a long running Issue that wasn't logged

## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [X] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [X] Code has been commented, particularly in hard-to-understand areas
- [X] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [X] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
