### PR TITLE
feat: add Jellyfin 12.0 build target

### DIFF
--- a/Jellyfin.Plugin.Themerr/Jellyfin.Plugin.Themerr.csproj
+++ b/Jellyfin.Plugin.Themerr/Jellyfin.Plugin.Themerr.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
     <FileVersion>0.0.0.0</FileVersion>
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.11" /> <!-- Must match version from Jellyfin.Controller -->
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.0-rc5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" /> <!-- Must match version from Jellyfin.Controller -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="JsonExtensions" Version="1.2.3" />
     <PackageReference Include="YoutubeExplode" Version="6.6.1" />

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,26 @@ def get_package_version(file_path: str, package_name: str):
     return None
 
 
+def get_jellyfin_source_ref(version: str | None):
+    """
+    Map the ``Jellyfin.Controller`` NuGet version to the matching git tag.
+
+    Stable packages share the tag's three-part version (``10.11.11`` ->
+    ``v10.11.11``), but pre-releases drop the patch component: the NuGet package
+    ``12.0.0-rc5`` is tagged ``v12.0-rc5``. Emitting ``v12.0.0-rc5`` 404s, and
+    since most ``sphinx_csharp_ext_search_pages`` entries have no fallback URL,
+    sphinx_csharp raises ``IndexError`` rather than reporting a broken link.
+    """
+    if version is None:
+        return None
+
+    base, sep, pre = version.partition('-')
+    if sep:
+        base = '.'.join(base.split('.')[:2])
+
+    return f'v{base}{sep}{pre}'
+
+
 def get_major_minor_version(version: str | None):
     if version is None:
         return None
@@ -73,6 +93,7 @@ youtube_explode_version = get_package_version(
     package_name='YoutubeExplode',
 )
 efcore_doc_version = get_major_minor_version(efcore_version) or dotnet_version
+jellyfin_source_ref = get_jellyfin_source_ref(jellyfin_version)
 
 # The full version, including alpha/beta/rc tags
 # https://docs.readthedocs.io/en/stable/reference/environment-variables.html#envvar-READTHEDOCS_VERSION
@@ -182,40 +203,40 @@ sphinx_csharp_ext_search_pages = {
         f'https://www.nuget.org/packages/YoutubeExplode/{youtube_explode_version}#%s',
     ),
     'Jellyfin.Controller.MediaBrowser.Common.Configuration': (
-        f'https://github.com/jellyfin/jellyfin/blob/v{jellyfin_version}/MediaBrowser.Common/Configuration/%s.cs',
+        f'https://github.com/jellyfin/jellyfin/blob/{jellyfin_source_ref}/MediaBrowser.Common/Configuration/%s.cs',
     ),
     'Jellyfin.Controller.MediaBrowser.Common.Plugins': (
-        f'https://github.com/jellyfin/jellyfin/blob/v{jellyfin_version}/MediaBrowser.Common/Plugins/%s.cs',
+        f'https://github.com/jellyfin/jellyfin/blob/{jellyfin_source_ref}/MediaBrowser.Common/Plugins/%s.cs',
     ),
     'Jellyfin.Controller.MediaBrowser.Controller': (
-        f'https://github.com/jellyfin/jellyfin/blob/v{jellyfin_version}/MediaBrowser.Controller/%s.cs',
+        f'https://github.com/jellyfin/jellyfin/blob/{jellyfin_source_ref}/MediaBrowser.Controller/%s.cs',
     ),
     'Jellyfin.Controller.MediaBrowser.Controller.Configuration': (
-        f'https://github.com/jellyfin/jellyfin/blob/v{jellyfin_version}/MediaBrowser.Controller/Configuration/%s.cs',
+        f'https://github.com/jellyfin/jellyfin/blob/{jellyfin_source_ref}/MediaBrowser.Controller/Configuration/%s.cs',
     ),
     'Jellyfin.Controller.MediaBrowser.Controller.Entities': (
-        f'https://github.com/jellyfin/jellyfin/blob/v{jellyfin_version}/MediaBrowser.Controller/Entities/%s.cs',
+        f'https://github.com/jellyfin/jellyfin/blob/{jellyfin_source_ref}/MediaBrowser.Controller/Entities/%s.cs',
     ),
     'Jellyfin.Controller.MediaBrowser.Controller.Entities.Movies': (
-        f'https://github.com/jellyfin/jellyfin/blob/v{jellyfin_version}/MediaBrowser.Controller/Entities/Movies/%s.cs',
+        f'https://github.com/jellyfin/jellyfin/blob/{jellyfin_source_ref}/MediaBrowser.Controller/Entities/Movies/%s.cs',
     ),
     'Jellyfin.Controller.MediaBrowser.Controller.Entities.TV': (
-        f'https://github.com/jellyfin/jellyfin/blob/v{jellyfin_version}/MediaBrowser.Controller/Entities/TV/%s.cs',
+        f'https://github.com/jellyfin/jellyfin/blob/{jellyfin_source_ref}/MediaBrowser.Controller/Entities/TV/%s.cs',
     ),
     'Jellyfin.Controller.MediaBrowser.Controller.Entities.Library': (
-        f'https://github.com/jellyfin/jellyfin/blob/v{jellyfin_version}/MediaBrowser.Controller/Library/%s.cs',
+        f'https://github.com/jellyfin/jellyfin/blob/{jellyfin_source_ref}/MediaBrowser.Controller/Library/%s.cs',
     ),
     'Jellyfin.Controller.MediaBrowser.Controller.Plugins': (
-        f'https://github.com/jellyfin/jellyfin/blob/v{jellyfin_version}/MediaBrowser.Controller/Plugins/%s.cs',
+        f'https://github.com/jellyfin/jellyfin/blob/{jellyfin_source_ref}/MediaBrowser.Controller/Plugins/%s.cs',
     ),
     'Jellyfin.Controller.MediaBrowser.Model.Plugins': (
-        f'https://github.com/jellyfin/jellyfin/blob/v{jellyfin_version}/MediaBrowser.Model/Plugins/%s.cs',
+        f'https://github.com/jellyfin/jellyfin/blob/{jellyfin_source_ref}/MediaBrowser.Model/Plugins/%s.cs',
     ),
     'Jellyfin.Controller.MediaBrowser.Model.Serialization': (
-        f'https://github.com/jellyfin/jellyfin/blob/v{jellyfin_version}/MediaBrowser.Model/Serialization/%s.cs',
+        f'https://github.com/jellyfin/jellyfin/blob/{jellyfin_source_ref}/MediaBrowser.Model/Serialization/%s.cs',
     ),
     'Jellyfin.Controller.MediaBrowser.Model.Tasks': (
-        f'https://github.com/jellyfin/jellyfin/blob/v{jellyfin_version}/MediaBrowser.Model/Tasks/%s.cs',
+        f'https://github.com/jellyfin/jellyfin/blob/{jellyfin_source_ref}/MediaBrowser.Model/Tasks/%s.cs',
     ),
 }
 

--- a/docs/source/contributing/build.rst
+++ b/docs/source/contributing/build.rst
@@ -3,7 +3,7 @@ Build
 Compiling Themerr-jellyfin requires the following:
 
 - `git <https://git-scm.com/>`__
-- `.net9.0 SDK <https://dotnet.microsoft.com/en-us/download/dotnet/9.0>`__
+- `.net10.0 SDK <https://dotnet.microsoft.com/en-us/download/dotnet/10.0>`__
 - `python >=3.14 <https://www.python.org/downloads/>`__
 - `uv <https://docs.astral.sh/uv/>`__
 


### PR DESCRIPTION
Adds a Jellyfin 12.0 build target.

Retargets to `net10.0` against the Jellyfin `12.0.0-rc5` NuGet packages. Where the project already
parameterises on `<JellyfinVersion>`, this just teaches that existing machinery about 12.x and
leaves the older targets untouched.

Built and loaded successfully on Jellyfin 12.0-rc5.
